### PR TITLE
Changed deroot function

### DIFF
--- a/treeswift/Tree.py
+++ b/treeswift/Tree.py
@@ -243,7 +243,7 @@ class Tree:
         for node in to_contract:
             node.contract()
 
-    def deroot(self, label='OLDROOT'):
+    def drop_edge_length_at_root(self, label='OLDROOT'):
         '''If the tree has a root edge, drop the edge to be a child of the root node
 
         Args:
@@ -252,6 +252,21 @@ class Tree:
         if self.root.edge_length is not None:
             self.root.add_child(Node(edge_length=self.root.edge_length,label=label))
             self.root.edge_length = None
+
+    def deroot(self):
+        '''If tree bifurcates at the root, contract an edge incident with the root to create a trifurcation at the root.
+
+        Args:
+            ``label`` (``str``): The desired label of the new child
+        '''
+        if self.root.num_children() == 1:
+            warn("Unable to unroot tree with unifurcation at the root!")
+        elif self.root.num_children() == 2:
+            [left, right] = self.root.child_nodes()
+            if left.is_leaf():
+                right.contract()
+            else:
+                left.contract()
 
     def diameter(self):
         '''Compute the diameter (maximum leaf pairwise distance) of this ``Tree``


### PR DESCRIPTION
to have the same meaning as the [DendroPy deroot function](https://dendropy.org/_modules/dendropy/datamodel/treemodel.html#Tree). This isn't a bug fix, but it definitely caused me some confusion when I was moving code that I had implemented in DendroPy over to TreeSwift. If you want to add this functionality without renaming the TreeSwift functions, you could accept this pull request and then change "deroot" to "unroot" and change "drop_edge_length_at_root" back to "deroot". Thanks for considering!  